### PR TITLE
Added build status with link to Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Soteria
 
+[![Build Status](https://travis-ci.org/javaee-security-spec/soteria.svg?branch=master)](https://travis-ci.org/javaee-security-spec/soteria)
+
 Java EE Security (JSR 375) upstream API and RI
 
 Notes


### PR DESCRIPTION
I don't know Travis, but in Jenkins you can download the resulting binary file of the build. That would be useful for users who want to test the latest version without need to compile it themselves.
