### PR TITLE
Simplified CredentialValidationResult creation

### DIFF
--- a/api/src/main/java/javax/security/identitystore/CredentialValidationResult.java
+++ b/api/src/main/java/javax/security/identitystore/CredentialValidationResult.java
@@ -39,15 +39,13 @@
  */
 package javax.security.identitystore;
 
+import java.util.ArrayList;
 import static java.util.Collections.unmodifiableList;
+import java.util.List;
+import javax.security.CallerPrincipal;
 import static javax.security.identitystore.CredentialValidationResult.Status.INVALID;
 import static javax.security.identitystore.CredentialValidationResult.Status.NOT_VALIDATED;
 import static javax.security.identitystore.CredentialValidationResult.Status.VALID;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.security.CallerPrincipal;
 import javax.security.identitystore.credential.Credential;
 
 /**
@@ -58,109 +56,112 @@ import javax.security.identitystore.credential.Credential;
  */
 public class CredentialValidationResult {
 
-	public static final CredentialValidationResult INVALID_RESULT = new CredentialValidationResult(INVALID, null, null);
-    public static final CredentialValidationResult NOT_VALIDATED_RESULT = new CredentialValidationResult(NOT_VALIDATED, null, null);
+    public static final CredentialValidationResult INVALID_RESULT = new CredentialValidationResult(INVALID);
+    public static final CredentialValidationResult NOT_VALIDATED_RESULT = new CredentialValidationResult(NOT_VALIDATED);
 
     private final CallerPrincipal callerPrincipal;
-	private final Status status;
-	private final List<String> groups;
+    private final Status status;
+    private final List<String> groups;
 
-	public enum Status {
-		/**
-		 * Indicates that the credential could not be validated
-		 */
-		NOT_VALIDATED,
+    public enum Status {
+        /**
+         * Indicates that the credential could not be validated
+         */
+        NOT_VALIDATED,
+        /**
+         * Indicates that the credential is not valid after a validation
+         * attempt.
+         */
+        INVALID,
+        /**
+         * Indicates that the credential is valid after a validation attempt.
+         */
+        VALID
+    };
 
-		/**
-		 * Indicates that the credential is not valid after a validation
-		 * attempt.
-		 */
-		INVALID,
-
-		/**
-		 * Indicates that the credential is valid after a validation attempt.
-		 */
-		VALID
-	};
-	
-	/**
+    /**
      * Constructor for a VALID result
-     * 
-     * @param callerName
-     *            Name of the validated caller
-     * @param groups
-     *            Groups associated with the caller from the identity store
+     *
+     * @param callerName Name of the validated caller
+     * @param groups Groups associated with the caller from the identity store
      */
     public CredentialValidationResult(String callerName, List<String> groups) {
         this(new CallerPrincipal(callerName), groups);
     }
-	
-	/**
+
+    /**
      * Constructor for a VALID result
-     * 
-     * @param callerPrincipal
-     *            Validated caller
-     * @param groups
-     *            Groups associated with the caller from the identity store
+     *
+     * @param callerPrincipal Validated caller
+     * @param groups Groups associated with the caller from the identity store
      */
-	public CredentialValidationResult(CallerPrincipal callerPrincipal, List<String> groups) {
-	    this(VALID, callerPrincipal, groups);
-	}
-	
-	/**
-	 * Constructor
-	 *
-	 * @param status
-	 *            Validation status
-	 * @param callerPrincipal
-	 *            Validated caller
-	 * @param groups
-	 *            Groups associated with the caller from the identity store
-	 */
-	public CredentialValidationResult(Status status, CallerPrincipal callerPrincipal, List<String> groups) {
+    public CredentialValidationResult(CallerPrincipal callerPrincipal, List<String> groups) {
+        this(VALID, callerPrincipal, groups);
+    }
 
-		if (null == status) {
-			throw new NullPointerException("status");
-		}
+    /**
+     * Constructor for a NOT_VALIDATED or INVALID result
+     *
+     * @param status Validation status
+     */
+    private CredentialValidationResult(Status status) {
+        this(status, null, null);
+        if (VALID == status) {
+            throw new IllegalArgumentException("status");
+        }
+    }
 
-		this.status = status;
-		this.callerPrincipal = callerPrincipal;
+    /**
+     * Constructor
+     *
+     * @param status Validation status
+     * @param callerPrincipal Validated caller
+     * @param groups Groups associated with the caller from the identity store
+     */
+    private CredentialValidationResult(Status status, CallerPrincipal callerPrincipal, List<String> groups) {
 
-		if (VALID == status) {
-			if (null != groups) {
-				groups = unmodifiableList(new ArrayList<>(groups));
-			}
-			this.groups = groups;
-		} else {
-			this.groups = null;
-		}
-	}
+        if (null == status) {
+            throw new NullPointerException("status");
+        }
 
-	/**
-	 * Determines the validation status.
-	 *
-	 * @return The validation status
-	 */
-	public Status getStatus() {
-		return status;
-	}
-	
+        this.status = status;
+
+        if (VALID == status) {
+            if (null != groups) {
+                groups = unmodifiableList(new ArrayList<>(groups));
+            }
+            this.groups = groups;
+            this.callerPrincipal = callerPrincipal;
+        } else {
+            this.callerPrincipal = null;
+            this.groups = null;
+        }
+    }
+
+    /**
+     * Determines the validation status.
+     *
+     * @return The validation status
+     */
+    public Status getStatus() {
+        return status;
+    }
+
     public CallerPrincipal getCallerPrincipal() {
         return callerPrincipal;
     }
 
-	/**
-	 * Determines the list of groups that the specified Caller is in, based on
-	 * the associated persistence store..
-	 *
-	 * @return The list of groups that the specified Caller is in, empty if
-	 *         none. <code>null</code> if {@link #getStatus} does not return
-	 *         {@link Status#VALID VALID} or if the identity store does not
-	 *         support groups.
-	 */
-	public List<String> getCallerGroups() {
-		return groups;
-	}
-    
+    /**
+     * Determines the list of groups that the specified Caller is in, based on
+     * the associated persistence store..
+     *
+     * @return The list of groups that the specified Caller is in, empty if
+     * none. <code>null</code> if {@link #getStatus} does not return
+     * {@link Status#VALID VALID} or if the identity store does not support
+     * groups.
+     */
+    public List<String> getCallerGroups() {
+        return groups;
+    }
 
 }

--- a/impl/src/main/java/org/glassfish/soteria/cdi/LoginToContinueInterceptor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/LoginToContinueInterceptor.java
@@ -43,7 +43,6 @@ import static java.lang.Boolean.TRUE;
 import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
 import static javax.security.auth.message.AuthStatus.SEND_FAILURE;
 import static javax.security.auth.message.AuthStatus.SUCCESS;
-import static javax.security.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.Utils.getBaseURL;
 import static org.glassfish.soteria.Utils.getParam;
 import static org.glassfish.soteria.Utils.isEmpty;
@@ -226,7 +225,6 @@ public class LoginToContinueInterceptor implements Serializable {
                     // URL. This is needed since the underlying JASPIC runtime does not
                     // remember the authenticated identity if we redirect.
                     saveAuthentication(request, new CredentialValidationResult(
-                        VALID,
                         httpMessageContext.getCallerPrincipal(),
                         httpMessageContext.getGroups()));
                     

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/DataBaseIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/DataBaseIdentityStore.java
@@ -41,7 +41,6 @@ package org.glassfish.soteria.identitystores;
 
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static javax.security.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
-import static javax.security.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.cdi.CdiUtils.jndiLookup;
 
 import java.sql.Connection;
@@ -88,7 +87,6 @@ public class DataBaseIdentityStore implements IdentityStore {
         
         if (!passwords.isEmpty() && usernamePasswordCredential.getPassword().compareTo(passwords.get(0))) {
             return new CredentialValidationResult(
-                VALID, 
                 new CallerPrincipal(usernamePasswordCredential.getCaller()), 
                 executeQuery(
                     dataSource, 

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/EmbeddedIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/EmbeddedIdentityStore.java
@@ -44,7 +44,6 @@ import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toMap;
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static javax.security.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
-import static javax.security.identitystore.CredentialValidationResult.Status.VALID;
 
 import java.util.Map;
 
@@ -80,7 +79,6 @@ public class EmbeddedIdentityStore implements IdentityStore {
 
         if (credentials != null && usernamePasswordCredential.getPassword().compareTo(credentials.password())) {
             return new CredentialValidationResult(
-                VALID, 
                 new CallerPrincipal(credentials.callerName()), 
                 asList(credentials.groups())
             );

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/LDapIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/LDapIdentityStore.java
@@ -60,7 +60,6 @@ import static java.util.Collections.list;
 import static javax.naming.Context.*;
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static javax.security.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
-import static javax.security.identitystore.CredentialValidationResult.Status.VALID;
 
 public class LDapIdentityStore implements IdentityStore {
 
@@ -121,7 +120,6 @@ public class LDapIdentityStore implements IdentityStore {
             closeContext(ldapContext);
 
             return new CredentialValidationResult(
-                    VALID,
                     new CallerPrincipal(usernamePasswordCredential.getCaller()),
                     groups
             );
@@ -170,7 +168,6 @@ public class LDapIdentityStore implements IdentityStore {
         closeContext(ldapContext);
 
         return new CredentialValidationResult(
-                VALID,
                 new CallerPrincipal(usernamePasswordCredential.getCaller()),
                 groups
         );

--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -3,7 +3,6 @@ package org.glassfish.soteria.test;
 import static java.util.Arrays.asList;
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static javax.security.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
-import static javax.security.identitystore.CredentialValidationResult.Status.VALID;
 
 import javax.enterprise.context.RequestScoped;
 import javax.security.CallerPrincipal;
@@ -29,7 +28,6 @@ public class TestIdentityStore implements IdentityStore {
             usernamePasswordCredential.getPassword().compareTo("secret1")) {
             
             return new CredentialValidationResult(
-                VALID, 
                 new CallerPrincipal("reza"), 
                 asList("foo", "bar")
             );

--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestRememberMeIdentityStore.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestRememberMeIdentityStore.java
@@ -1,7 +1,6 @@
 package org.glassfish.soteria.test;
 
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
-import static javax.security.identitystore.CredentialValidationResult.Status.VALID;
 
 import java.util.List;
 import java.util.Map;
@@ -34,7 +33,7 @@ public class TestRememberMeIdentityStore implements RememberMeIdentityStore {
 		
 		// NOTE: FOR EXAMPLE ONLY. AS TOKENKEY WOULD EFFECTIVELY BECOME THE REPLACEMENT PASSWORD
 		// IT SHOULD NORMALLY NOT BE STORED DIRECTLY BUT EG USING STRONG HASHING
-		identities.put(token, new CredentialValidationResult(VALID, callerPrincipal, groups));
+		identities.put(token, new CredentialValidationResult(callerPrincipal, groups));
 		
 		return token;
 	}

--- a/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -3,7 +3,6 @@ package org.glassfish.soteria.test;
 import static java.util.Arrays.asList;
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static javax.security.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
-import static javax.security.identitystore.CredentialValidationResult.Status.VALID;
 
 import javax.enterprise.context.RequestScoped;
 import javax.security.CallerPrincipal;
@@ -29,7 +28,6 @@ public class TestIdentityStore implements IdentityStore {
             usernamePasswordCredential.getPassword().compareTo("secret1")) {
             
             return new CredentialValidationResult(
-                VALID, 
                 new CallerPrincipal("reza"), 
                 asList("foo", "bar")
             );

--- a/test/app-custom/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -3,7 +3,6 @@ package org.glassfish.soteria.test;
 import static java.util.Arrays.asList;
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static javax.security.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
-import static javax.security.identitystore.CredentialValidationResult.Status.VALID;
 
 import javax.enterprise.context.RequestScoped;
 import javax.security.CallerPrincipal;
@@ -29,7 +28,6 @@ public class TestIdentityStore implements IdentityStore {
             usernamePasswordCredential.getPassword().compareTo("secret1")) {
             
             return new CredentialValidationResult(
-                VALID, 
                 new CallerPrincipal("reza"), 
                 asList("foo", "bar")
             );


### PR DESCRIPTION
This is a proposal. Since JASPIC mandates caller principal and groups to be null in case of invalid credential, I think it doesn't make sense to allow the creation of an invalid result with data. This way the user may only create valid results, or reuse the provided invalid ones.

Formatting was pretty ugly in CredentialValidationResult class so I reformated it. I could revert that change if needed.
