### PR TITLE
Update implementation to match current javax.security API spec

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>javax.security</groupId>
             <artifactId>javax.security-api</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-prd</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
        <groupId>org.glassfish.soteria</groupId>
        <artifactId>parent</artifactId>
-       <version>1.0-m04-SNAPSHOT</version>
+       <version>1.0-m05-SNAPSHOT</version>
     </parent>
 
     <artifactId>soteria</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>javax.security</groupId>
             <artifactId>javax.security-api</artifactId>
-            <version>1.0-m04-prd</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
        <groupId>org.glassfish.soteria</groupId>
        <artifactId>parent</artifactId>
-       <version>1.0-m03-SNAPSHOT</version>
+       <version>1.0-m04-SNAPSHOT</version>
     </parent>
 
     <artifactId>soteria</artifactId>

--- a/impl/src/main/java/org/glassfish/soteria/SecurityContextImpl.java
+++ b/impl/src/main/java/org/glassfish/soteria/SecurityContextImpl.java
@@ -83,7 +83,6 @@ public class SecurityContextImpl implements SecurityContext, Serializable {
     	return callerDetailsResolver.isCallerInRole(role);
     }
     
-    @Override
     public List<String> getAllDeclaredCallerRoles() {
         return callerDetailsResolver.getAllDeclaredCallerRoles();
     }

--- a/impl/src/main/java/org/glassfish/soteria/cdi/DefaultIdentityStoreHandler.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/DefaultIdentityStoreHandler.java
@@ -48,7 +48,9 @@ import static javax.security.identitystore.IdentityStore.ValidationType.VALIDATE
 import static org.glassfish.soteria.cdi.CdiUtils.getBeanReferencesByType;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.security.CallerPrincipal;
 import javax.security.identitystore.CredentialValidationResult;
@@ -104,7 +106,7 @@ public class DefaultIdentityStoreHandler implements IdentityStoreHandler {
         }
 
         CallerPrincipal callerPrincipal = validationResult.getCallerPrincipal();
-        List<String> groups = new ArrayList<>();
+        Set<String> groups = new HashSet<>();
 
         // Take the groups from the identity store that validated the credentials only
         // if it has been set to provide groups.
@@ -115,7 +117,7 @@ public class DefaultIdentityStoreHandler implements IdentityStoreHandler {
         // Ask all stores that were configured for group providing only to get the groups for the
         // authenticated caller
         for (IdentityStore authorizationIdentityStore : authorizationIdentityStores) {
-            groups.addAll(authorizationIdentityStore.getGroupsByCallerPrincipal(callerPrincipal));
+            groups.addAll(authorizationIdentityStore.getCallerGroups(validationResult));
         }
 
         return new CredentialValidationResult(callerPrincipal, groups);

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/DataBaseIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/DataBaseIdentityStore.java
@@ -96,11 +96,11 @@ public class DataBaseIdentityStore implements IdentityStore {
         if (!passwords.isEmpty() && usernamePasswordCredential.getPassword().compareTo(passwords.get(0))) {
             return new CredentialValidationResult(
                 new CallerPrincipal(usernamePasswordCredential.getCaller()), 
-                executeQuery(
-                    dataSource, 
+                new HashSet<>(executeQuery(
+                    dataSource,
                     dataBaseIdentityStoreDefinition.groupsQuery(),
                     usernamePasswordCredential.getCaller()
-                )
+                ))
             );
         }
 
@@ -108,14 +108,14 @@ public class DataBaseIdentityStore implements IdentityStore {
     }
     
     @Override
-    public Set<String> getGroupsByCallerPrincipal(CallerPrincipal callerPrincipal) {
+    public Set<String> getCallerGroups(CredentialValidationResult validationResult) {
         
         DataSource dataSource = jndiLookup(dataBaseIdentityStoreDefinition.dataSourceLookup());
         
         return new HashSet<>(executeQuery(
             dataSource,
             dataBaseIdentityStoreDefinition.groupsQuery(),
-            callerPrincipal.getName())
+            validationResult.getCallerPrincipal().getName())
         );
     }
 

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/EmbeddedIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/EmbeddedIdentityStore.java
@@ -91,7 +91,7 @@ public class EmbeddedIdentityStore implements IdentityStore {
         if (credentials != null && usernamePasswordCredential.getPassword().compareTo(credentials.password())) {
             return new CredentialValidationResult(
                 new CallerPrincipal(credentials.callerName()), 
-                asList(credentials.groups())
+                new HashSet<>(asList(credentials.groups()))
             );
         }
 
@@ -99,11 +99,10 @@ public class EmbeddedIdentityStore implements IdentityStore {
     }
     
     @Override
-    public Set<String> getGroupsByCallerPrincipal(CallerPrincipal callerPrincipal) {
-        
-        Credentials credentials = callerToCredentials.get(callerPrincipal.getName());
-        
-        return credentials != null? new HashSet<>(asList(credentials.groups())) : emptySet();
+    public Set<String> getCallerGroups(CredentialValidationResult validationResult) {
+        Credentials credentials = callerToCredentials.get(validationResult.getCallerPrincipal().getName());
+
+        return credentials != null ? new HashSet<>(asList(credentials.groups())) : emptySet();
     }
 
     public int priority() {

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/LdapIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/LdapIdentityStore.java
@@ -102,7 +102,7 @@ public class LdapIdentityStore implements IdentityStore {
     }
     
     @Override
-    public Set<String> getGroupsByCallerPrincipal(CallerPrincipal callerPrincipal) {
+    public Set<String> getCallerGroups(CredentialValidationResult validationResult) {
         LdapContext ldapContext = createLdapContext(
                 ldapIdentityStoreDefinition.url(),
                 ldapIdentityStoreDefinition.baseDn(),
@@ -110,7 +110,7 @@ public class LdapIdentityStore implements IdentityStore {
         
         if (ldapContext != null) {
             try {
-                return new HashSet<>(retrieveGroupInformation(callerPrincipal.getName(), ldapContext));
+                return new HashSet<>(retrieveGroupInformation(validationResult.getCallerPrincipal().getName(), ldapContext));
             } finally {
                 closeContext(ldapContext);
             }
@@ -146,7 +146,7 @@ public class LdapIdentityStore implements IdentityStore {
                 return INVALID_RESULT;
             }
 
-            List<String> groups = retrieveGroupInformation(callerDn, ldapContext);
+            Set<String> groups = retrieveGroupInformation(callerDn, ldapContext);
 
             closeContext(ldapContext);
 
@@ -194,7 +194,7 @@ public class LdapIdentityStore implements IdentityStore {
             return INVALID_RESULT;
         }
 
-        List<String> groups = retrieveGroupInformation(callerDn, ldapContext);
+        Set<String> groups = retrieveGroupInformation(callerDn, ldapContext);
 
         closeContext(ldapContext);
 
@@ -212,7 +212,7 @@ public class LdapIdentityStore implements IdentityStore {
         }
     }
 
-    private List<String> retrieveGroupInformation(String callerDn, LdapContext ldapContext) {
+    private Set<String> retrieveGroupInformation(String callerDn, LdapContext ldapContext) {
         // Search for the groups starting from the groupBaseDn,
         // Search for groupCallerDnAttribute equal to callerDn
         // Return groupNameAttribute
@@ -225,7 +225,7 @@ public class LdapIdentityStore implements IdentityStore {
         );
 
         // Collect the groups from the search results
-        List<String> groups = new ArrayList<>();
+        Set<String> groups = new HashSet<>();
         for (SearchResult searchResult : searchResults) {
             for (Object group : get(searchResult, ldapIdentityStoreDefinition.groupNameAttribute())) {
                 groups.add(group.toString());

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/HttpMessageContextImpl.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/HttpMessageContextImpl.java
@@ -50,8 +50,10 @@ import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.security.AuthenticationStatus;
 import javax.security.CallerPrincipal;
@@ -85,7 +87,7 @@ public class HttpMessageContextImpl implements HttpMessageContext {
     private AuthenticationParameters authParameters;
 
     private CallerPrincipal callerPrincipal;
-    private List<String> groups;
+    private Set<String> groups;
     
     public HttpMessageContextImpl(CallbackHandler handler, Map<String, String> moduleOptions, MessageInfo messageInfo, Subject clientSubject) {
         this.handler = handler;
@@ -126,11 +128,11 @@ public class HttpMessageContextImpl implements HttpMessageContext {
     }
 
     /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#setRegisterSession(java.lang.String, java.util.List)
+     * @see javax.security.authenticationmechanism.http.HttpMessageContext#setRegisterSession(java.lang.String, java.util.Set)
      */
     @Override
-    public void setRegisterSession(String username, List<String> roles) {
-        Jaspic.setRegisterSession(messageInfo, username, roles);
+    public void setRegisterSession(String username, Set<String> groups) {
+        Jaspic.setRegisterSession(messageInfo, username, new ArrayList<>(groups));
     }
     
     /* (non-Javadoc)
@@ -254,10 +256,10 @@ public class HttpMessageContextImpl implements HttpMessageContext {
     }
     
     /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#notifyContainerAboutLogin(java.lang.String, java.util.List)
+     * @see javax.security.authenticationmechanism.http.HttpMessageContext#notifyContainerAboutLogin(java.lang.String, java.util.Set)
      */
     @Override
-    public AuthenticationStatus notifyContainerAboutLogin(String callerName, List<String> groups) {
+    public AuthenticationStatus notifyContainerAboutLogin(String callerName, Set<String> groups) {
         CallerPrincipal callerPrincipal = null;
         if (callerName != null) {
             callerPrincipal = new CallerPrincipal(callerName); // TODO: or store username separately?
@@ -279,7 +281,7 @@ public class HttpMessageContextImpl implements HttpMessageContext {
     }
     
     @Override
-    public AuthenticationStatus notifyContainerAboutLogin(CallerPrincipal callerPrincipal, List<String> groups) {
+    public AuthenticationStatus notifyContainerAboutLogin(CallerPrincipal callerPrincipal, Set<String> groups) {
         this.callerPrincipal = callerPrincipal;
         if (callerPrincipal != null) {
             this.groups = groups;
@@ -287,7 +289,7 @@ public class HttpMessageContextImpl implements HttpMessageContext {
             this.groups = null;
         }
         
-        Jaspic.notifyContainerAboutLogin(clientSubject, handler, callerPrincipal, groups);
+        Jaspic.notifyContainerAboutLogin(clientSubject, handler, callerPrincipal, new ArrayList<>(groups));
         
         // Explicitly set a flag that we did authentication, so code can check that this happened
         // TODO: or throw CDI event here?
@@ -315,7 +317,7 @@ public class HttpMessageContextImpl implements HttpMessageContext {
     }
 
     @Override
-    public List<String> getGroups() {
+    public Set<String> getGroups() {
         return groups;
     }
 

--- a/impl/src/main/java/org/glassfish/soteria/servlet/SamRegistrationInstaller.java
+++ b/impl/src/main/java/org/glassfish/soteria/servlet/SamRegistrationInstaller.java
@@ -90,7 +90,7 @@ public class SamRegistrationInstaller implements ServletContainerInitializer, Se
             if (logger.isLoggable(INFO)) {
                 logger.log(INFO, 
                     // TODO: Get version from build
-                    "Initializing Soteria 1.0-m04-SNAPSHOT for context ''{0}''", 
+                    "Initializing Soteria 1.0-m05-SNAPSHOT for context ''{0}''", 
                     ctx.getContextPath());
             }
             

--- a/impl/src/main/java/org/glassfish/soteria/servlet/SamRegistrationInstaller.java
+++ b/impl/src/main/java/org/glassfish/soteria/servlet/SamRegistrationInstaller.java
@@ -90,7 +90,7 @@ public class SamRegistrationInstaller implements ServletContainerInitializer, Se
             if (logger.isLoggable(INFO)) {
                 logger.log(INFO, 
                     // TODO: Get version from build
-                    "Initializing Soteria 1.0-m03-SNAPSHOT for context ''{0}''", 
+                    "Initializing Soteria 1.0-m04-SNAPSHOT for context ''{0}''", 
                     ctx.getContextPath());
             }
             

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>org.glassfish.soteria</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.0-m04-SNAPSHOT</version>
+	<version>1.0-m05-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<inceptionYear>2015</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>org.glassfish.soteria</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.0-m03-SNAPSHOT</version>
+	<version>1.0-m04-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<inceptionYear>2015</inceptionYear>

--- a/test/app-custom-identity-store-handler/pom.xml
+++ b/test/app-custom-identity-store-handler/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 
 	<artifactId>app-custom-identity-store-handler</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/test/app-custom-identity-store-handler/pom.xml
+++ b/test/app-custom-identity-store-handler/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 
 	<artifactId>app-custom-identity-store-handler</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/CustomIdentityStoreHandler.java
+++ b/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/CustomIdentityStoreHandler.java
@@ -47,8 +47,9 @@ import static javax.security.identitystore.IdentityStore.ValidationType.PROVIDE_
 import static javax.security.identitystore.IdentityStore.ValidationType.VALIDATE;
 import static org.glassfish.soteria.cdi.CdiUtils.getBeanReferencesByType;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.Priority;
@@ -90,7 +91,7 @@ public class CustomIdentityStoreHandler implements IdentityStoreHandler {
     public CredentialValidationResult validate(Credential credential) {
         CredentialValidationResult  validationResult = null;
         IdentityStore identityStore = null;
-        
+
         // Check stores to validate until one succeeds.
         for (IdentityStore authenticationIdentityStore : validatingIdentityStores) {
             CredentialValidationResult temp = authenticationIdentityStore.validate(credential);
@@ -117,8 +118,8 @@ public class CustomIdentityStoreHandler implements IdentityStoreHandler {
         }
 
         CallerPrincipal callerPrincipal = validationResult.getCallerPrincipal();
-        
-        List<String> groups = new ArrayList<>();
+
+        Set<String> groups = new HashSet<>();
         if (identityStore.validationTypes().contains(PROVIDE_GROUPS)) {
             groups.addAll(validationResult.getCallerGroups());
         }
@@ -126,7 +127,7 @@ public class CustomIdentityStoreHandler implements IdentityStoreHandler {
         // Ask all stores that were configured for authorization to get the groups for the
         // authenticated caller
         for (IdentityStore authorizationIdentityStore : groupProvidingIdentityStores) {
-            groups.addAll(authorizationIdentityStore.getGroupsByCallerPrincipal(callerPrincipal));
+            groups.addAll(authorizationIdentityStore.getCallerGroups(validationResult));
         }
 
         return new CredentialValidationResult(callerPrincipal, groups);

--- a/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/GroupProviderIdentityStore.java
+++ b/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/GroupProviderIdentityStore.java
@@ -53,6 +53,7 @@ import java.util.Set;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.security.CallerPrincipal;
+import javax.security.identitystore.CredentialValidationResult;
 import javax.security.identitystore.IdentityStore;
 import javax.security.identitystore.annotation.LdapIdentityStoreDefinition;
 
@@ -82,13 +83,12 @@ public class GroupProviderIdentityStore implements IdentityStore {
     }
 
     @Override
-    public Set<String> getGroupsByCallerPrincipal(CallerPrincipal callerPrincipal) {
-
-        Set<String> result = groupsPerCaller.get(callerPrincipal.getName());
+    public Set<String> getCallerGroups(CredentialValidationResult validationResult) {
+        Set<String> result = groupsPerCaller.get(validationResult.getCallerPrincipal().getName());
         if (result == null) {
             result = emptySet();
         }
-        
+
         return result;
     }
 

--- a/test/app-custom-rememberme/pom.xml
+++ b/test/app-custom-rememberme/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-custom-rememberme</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-custom-rememberme/pom.xml
+++ b/test/app-custom-rememberme/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-custom-rememberme</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -43,6 +43,8 @@ import static java.util.Arrays.asList;
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static javax.security.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
 
+import java.util.HashSet;
+
 import javax.enterprise.context.RequestScoped;
 import javax.security.identitystore.CredentialValidationResult;
 import javax.security.identitystore.IdentityStore;
@@ -66,7 +68,7 @@ public class TestIdentityStore implements IdentityStore {
         if (usernamePasswordCredential.getCaller().equals("reza") &&
                 usernamePasswordCredential.getPassword().compareTo("secret1")) {
 
-            return new CredentialValidationResult("reza", asList("foo", "bar"));
+            return new CredentialValidationResult("reza", new HashSet<>(asList("foo", "bar")));
         }
 
         return INVALID_RESULT;

--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestRememberMeIdentityStore.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestRememberMeIdentityStore.java
@@ -43,6 +43,7 @@ import static javax.security.identitystore.CredentialValidationResult.INVALID_RE
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -67,7 +68,7 @@ public class TestRememberMeIdentityStore implements RememberMeIdentityStore {
     }
 
     @Override
-    public String generateLoginToken(CallerPrincipal callerPrincipal, List<String> groups) {
+    public String generateLoginToken(CallerPrincipal callerPrincipal, Set<String> groups) {
         String token = UUID.randomUUID().toString();
 
         // NOTE: FOR EXAMPLE ONLY. AS TOKENKEY WOULD EFFECTIVELY BECOME THE REPLACEMENT PASSWORD

--- a/test/app-custom-session/pom.xml
+++ b/test/app-custom-session/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-custom-session</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-custom-session/pom.xml
+++ b/test/app-custom-session/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-custom-session</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -43,6 +43,9 @@ import static java.util.Arrays.asList;
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static javax.security.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
 
+import java.util.Arrays;
+import java.util.HashSet;
+
 import javax.enterprise.context.RequestScoped;
 import javax.security.identitystore.CredentialValidationResult;
 import javax.security.identitystore.IdentityStore;
@@ -64,7 +67,7 @@ public class TestIdentityStore implements IdentityStore {
     public CredentialValidationResult validate(UsernamePasswordCredential usernamePasswordCredential) {
 
         if (usernamePasswordCredential.compareTo("reza", "secret1")) {
-            return new CredentialValidationResult("reza", asList("foo", "bar"));
+            return new CredentialValidationResult("reza", new HashSet<>(asList("foo", "bar")));
         }
 
         return INVALID_RESULT;

--- a/test/app-custom/pom.xml
+++ b/test/app-custom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-custom</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-custom/pom.xml
+++ b/test/app-custom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-custom</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-custom/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-custom/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -50,6 +50,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.glassfish.soteria.SecurityContextImpl;
+
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether
  * this caller is in any of the roles {foo, bar, kaz}
@@ -94,7 +96,7 @@ public class Servlet extends HttpServlet {
         
         response.getWriter().write("has access " + securityContext.hasAccessToWebResource("/protectedServlet") + "\n");
         
-        response.getWriter().write("All declared roles of user " + securityContext.getAllDeclaredCallerRoles() + "\n");
+        response.getWriter().write("All declared roles of user " + ((SecurityContextImpl)securityContext).getAllDeclaredCallerRoles() + "\n");
     }
 
 }

--- a/test/app-custom/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -42,6 +42,8 @@ package org.glassfish.soteria.test;
 import static java.util.Arrays.asList;
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
 
+import java.util.HashSet;
+
 import javax.enterprise.context.RequestScoped;
 import javax.security.identitystore.CredentialValidationResult;
 import javax.security.identitystore.IdentityStore;
@@ -53,10 +55,10 @@ public class TestIdentityStore implements IdentityStore {
     public CredentialValidationResult validate(UsernamePasswordCredential usernamePasswordCredential) {
 
         if (usernamePasswordCredential.compareTo("reza", "secret1")) {
-            return new CredentialValidationResult("reza", asList("foo", "bar"));
+            return new CredentialValidationResult("reza", new HashSet<>(asList("foo", "bar")));
         }
 
         return INVALID_RESULT;
     }
-	
+
 }

--- a/test/app-db/pom.xml
+++ b/test/app-db/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-db</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
         
          <dependency>

--- a/test/app-db/pom.xml
+++ b/test/app-db/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-db</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
         
          <dependency>

--- a/test/app-jaxrs/pom.xml
+++ b/test/app-jaxrs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-jaxrs</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-jaxrs/pom.xml
+++ b/test/app-jaxrs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-jaxrs</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -43,6 +43,8 @@ import static java.util.Arrays.asList;
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static org.glassfish.soteria.Utils.notNull;
 
+import java.util.HashSet;
+
 import javax.enterprise.context.RequestScoped;
 import javax.security.AuthenticationStatus;
 import javax.security.auth.message.AuthException;
@@ -75,7 +77,7 @@ public class TestAuthenticationMechanism implements HttpAuthenticationMechanism 
     public CredentialValidationResult validate(UsernamePasswordCredential usernamePasswordCredential) {
 
         if (usernamePasswordCredential.compareTo("reza", "secret1")) {
-            return new CredentialValidationResult("reza", asList("foo", "bar"));
+            return new CredentialValidationResult("reza", new HashSet<>(asList("foo", "bar")));
         }
 
         return INVALID_RESULT;

--- a/test/app-ldap/pom.xml
+++ b/test/app-ldap/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-ldap</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
         
         <dependency>

--- a/test/app-ldap/pom.xml
+++ b/test/app-ldap/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-ldap</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
         
         <dependency>

--- a/test/app-ldap2/pom.xml
+++ b/test/app-ldap2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
         
          <dependency>

--- a/test/app-ldap2/pom.xml
+++ b/test/app-ldap2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
         
          <dependency>

--- a/test/app-mem-basic/pom.xml
+++ b/test/app-mem-basic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
     <artifactId>app-mem-basic</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/test/app-mem-basic/pom.xml
+++ b/test/app-mem-basic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
     <artifactId>app-mem-basic</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/test/app-mem-customform/pom.xml
+++ b/test/app-mem-customform/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-mem-customform</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/test/app-mem-customform/pom.xml
+++ b/test/app-mem-customform/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-mem-customform</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/test/app-mem-form/pom.xml
+++ b/test/app-mem-form/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-mem-form</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/test/app-mem-form/pom.xml
+++ b/test/app-mem-form/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-mem-form</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/test/app-mem/pom.xml
+++ b/test/app-mem/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-mem</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-mem/pom.xml
+++ b/test/app-mem/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-mem</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-multiple-store-backup/pom.xml
+++ b/test/app-multiple-store-backup/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-multiple-store-backup</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-multiple-store-backup/pom.xml
+++ b/test/app-multiple-store-backup/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-multiple-store-backup</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestBackupIdentityStore.java
+++ b/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestBackupIdentityStore.java
@@ -43,6 +43,8 @@ import static java.util.Arrays.asList;
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static javax.security.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
 
+import java.util.HashSet;
+
 import javax.enterprise.context.RequestScoped;
 import javax.security.identitystore.CredentialValidationResult;
 import javax.security.identitystore.IdentityStore;
@@ -66,18 +68,18 @@ public class TestBackupIdentityStore implements IdentityStore {
         if (usernamePasswordCredential.getCaller().equals("reza") &&
                 usernamePasswordCredential.getPassword().compareTo("secret2")) {
 
-            return new CredentialValidationResult("reza", asList("foo", "bar"));
+            return new CredentialValidationResult("reza", new HashSet<>(asList("foo", "bar")));
         }
-        
+
         if (usernamePasswordCredential.getCaller().equals("alex") &&
                 usernamePasswordCredential.getPassword().compareTo("verysecret")) {
 
-            return new CredentialValidationResult("alex", asList("foo", "bar"));
+            return new CredentialValidationResult("alex", new HashSet<>(asList("foo", "bar")));
         }
 
         return INVALID_RESULT;
     }
-    
+
     public int priority() {
         return 20;
     }

--- a/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -43,6 +43,8 @@ import static java.util.Arrays.asList;
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static javax.security.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
 
+import java.util.HashSet;
+
 import javax.enterprise.context.RequestScoped;
 import javax.security.identitystore.CredentialValidationResult;
 import javax.security.identitystore.IdentityStore;
@@ -66,12 +68,12 @@ public class TestIdentityStore implements IdentityStore {
         if (usernamePasswordCredential.getCaller().equals("reza") &&
                 usernamePasswordCredential.getPassword().compareTo("secret1")) {
 
-            return new CredentialValidationResult("reza", asList("foo", "bar"));
+            return new CredentialValidationResult("reza", new HashSet<>(asList("foo", "bar")));
         }
 
         return INVALID_RESULT;
     }
-    
+
     public int priority() {
         return 10;
     }

--- a/test/app-multiple-store/pom.xml
+++ b/test/app-multiple-store/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-multiple-store</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-multiple-store/pom.xml
+++ b/test/app-multiple-store/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-multiple-store</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthorizationIdentityStore.java
+++ b/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthorizationIdentityStore.java
@@ -49,7 +49,7 @@ import java.util.Set;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.RequestScoped;
-import javax.security.CallerPrincipal;
+import javax.security.identitystore.CredentialValidationResult;
 import javax.security.identitystore.IdentityStore;
 
 /**
@@ -69,15 +69,15 @@ public class AuthorizationIdentityStore implements IdentityStore {
         authorization.put("arjan", new HashSet<>(asList("foo", "foo")));
 
     }
-    
+
     @Override
-    public Set<String> getGroupsByCallerPrincipal(CallerPrincipal callerPrincipal) {
-        return authorization.get(callerPrincipal.getName());
+    public Set<String> getCallerGroups(CredentialValidationResult validationResult) {
+        return authorization.get(validationResult.getCallerPrincipal().getName());
     }
 
     @Override
     public Set<ValidationType> validationTypes() {
         return new HashSet<>(asList(PROVIDE_GROUPS));
     }
-    
+
 }

--- a/test/app-securitycontext-auth/pom.xml
+++ b/test/app-securitycontext-auth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-securitycontext-auth</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-securitycontext-auth/pom.xml
+++ b/test/app-securitycontext-auth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-securitycontext-auth</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -56,6 +56,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.glassfish.soteria.SecurityContextImpl;
+
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether
  * this caller is in any of the roles {foo, bar, kaz}
@@ -66,28 +68,28 @@ import javax.servlet.http.HttpServletResponse;
 public class Servlet extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
-    
+
     @Inject
     private SecurityContext securityContext;
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        
+
         response.getWriter().write("This is a servlet \n");
-        
+
         String name = request.getParameter("name");
-        
+
         if (notNull(name)) {
-        
+
             AuthenticationStatus status = securityContext.authenticate(
                 request, response,
                 withParams()
                     .credential(
                         new CallerOnlyCredential(name)));
-            
+
             response.getWriter().write("Authenticated with status: " + status.name() + "\n");
         }
-        
+
         String webName = null;
         if (request.getUserPrincipal() != null) {
             webName = request.getUserPrincipal().getName();
@@ -98,24 +100,24 @@ public class Servlet extends HttpServlet {
         response.getWriter().write("web user has role \"foo\": " + request.isUserInRole("foo") + "\n");
         response.getWriter().write("web user has role \"bar\": " + request.isUserInRole("bar") + "\n");
         response.getWriter().write("web user has role \"kaz\": " + request.isUserInRole("kaz") + "\n");
-        
+
         String contextName = null;
         if (securityContext.getCallerPrincipal() != null) {
             contextName = securityContext.getCallerPrincipal().getName();
         }
-        
+
         response.getWriter().write("context username: " + contextName + "\n");
-        
+
         response.getWriter().write("context user has role \"foo\": " + securityContext.isCallerInRole("foo") + "\n");
         response.getWriter().write("context user has role \"bar\": " + securityContext.isCallerInRole("bar") + "\n");
         response.getWriter().write("context user has role \"kaz\": " + securityContext.isCallerInRole("kaz") + "\n");
-        
+
         response.getWriter().write("has access to /protectedServlet: " + securityContext.hasAccessToWebResource("/protectedServlet") + "\n");
-        
-        List<String> roles = securityContext.getAllDeclaredCallerRoles();
-        
+
+        List<String> roles = ((SecurityContextImpl)securityContext).getAllDeclaredCallerRoles();
+
         response.getWriter().write("All declared roles of user " + roles + "\n");
-        
+
         response.getWriter().write("all roles has role \"foo\": " + roles.contains("foo") + "\n");
         response.getWriter().write("all roles has role \"bar\": " + roles.contains("bar") + "\n");
         response.getWriter().write("all roles has role \"kaz\": " + roles.contains("kaz") + "\n");

--- a/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -42,6 +42,8 @@ package org.glassfish.soteria.test;
 import static java.util.Arrays.asList;
 import static javax.security.AuthenticationStatus.SEND_FAILURE;
 
+import java.util.HashSet;
+
 import javax.enterprise.context.RequestScoped;
 import javax.security.AuthenticationStatus;
 import javax.security.auth.message.AuthException;
@@ -59,27 +61,27 @@ public class TestAuthenticationMechanism implements HttpAuthenticationMechanism 
     public AuthenticationStatus validateRequest(HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) throws AuthException {
 
         if (httpMessageContext.isAuthenticationRequest()) {
-            
+
             Credential credential = httpMessageContext.getAuthParameters().getCredential();
             if (!(credential instanceof CallerOnlyCredential)) {
                 throw new IllegalStateException("This authentication mechanism requires a programmatically provided CallerOnlyCredential");
             }
-            
+
             CallerOnlyCredential callerOnlyCredential = (CallerOnlyCredential) credential;
-            
+
             if ("reza".equals(callerOnlyCredential.getCaller())) {
-                return httpMessageContext.notifyContainerAboutLogin("reza", asList("foo", "bar"));
+                return httpMessageContext.notifyContainerAboutLogin("reza", new HashSet<>(asList("foo", "bar")));
             }
-            
+
             if ("rezax".equals(callerOnlyCredential.getCaller())) {
                 throw new AuthException();
             }
-            
+
             return SEND_FAILURE;
-            
+
         }
-        
+
         return httpMessageContext.doNothing();
     }
-    
+
 }

--- a/test/app-securitycontext/pom.xml
+++ b/test/app-securitycontext/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-securitycontext</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m03-SNAPSHOT</version>
+            <version>1.0-m04-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-securitycontext/pom.xml
+++ b/test/app-securitycontext/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-securitycontext</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-m04-SNAPSHOT</version>
+            <version>1.0-m05-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -51,6 +51,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.glassfish.soteria.SecurityContextImpl;
+
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether
  * this caller is in any of the roles {foo, bar, kaz}
@@ -94,7 +96,7 @@ public class Servlet extends HttpServlet {
         
         response.getWriter().write("has access to /protectedServlet: " + securityContext.hasAccessToWebResource("/protectedServlet") + "\n");
         
-        List<String> roles = securityContext.getAllDeclaredCallerRoles();
+        List<String> roles = ((SecurityContextImpl)securityContext).getAllDeclaredCallerRoles();
         
         response.getWriter().write("All declared roles of user " + roles + "\n");
         

--- a/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -43,6 +43,8 @@ import static java.util.Arrays.asList;
 import static javax.security.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static org.glassfish.soteria.Utils.notNull;
 
+import java.util.HashSet;
+
 import javax.enterprise.context.RequestScoped;
 import javax.security.AuthenticationStatus;
 import javax.security.auth.message.AuthException;
@@ -61,24 +63,24 @@ public class TestAuthenticationMechanism implements HttpAuthenticationMechanism 
 
         String name = request.getParameter("name");
         String password = request.getParameter("password");
-    	
+
         if (notNull(name, password)) {
             return httpMessageContext.notifyContainerAboutLogin(
                 validate(
                     new UsernamePasswordCredential(name, password)));
-                
-        } 
+
+        }
 
         return httpMessageContext.doNothing();
     }
-    
+
     public CredentialValidationResult validate(UsernamePasswordCredential usernamePasswordCredential) {
 
         if (usernamePasswordCredential.compareTo("reza", "secret1")) {
-            return new CredentialValidationResult("reza", asList("foo", "bar"));
+            return new CredentialValidationResult("reza", new HashSet<>(asList("foo", "bar")));
         }
 
         return INVALID_RESULT;
     }
-    
+
 }

--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m04-SNAPSHOT</version>
+        <version>1.0-m05-SNAPSHOT</version>
     </parent>
     
     <artifactId>common</artifactId>

--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-m03-SNAPSHOT</version>
+        <version>1.0-m04-SNAPSHOT</version>
     </parent>
     
     <artifactId>common</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
        <groupId>org.glassfish.soteria</groupId>
        <artifactId>parent</artifactId>
-       <version>1.0-m03-SNAPSHOT</version>
+       <version>1.0-m04-SNAPSHOT</version>
     </parent>
     
     <groupId>org.glassfish.soteria.test</groupId>
@@ -121,7 +121,7 @@
         <!-- 
             This profile assumes a target that already has the Soteria libraries. 
             In Java EE 8 that would be the default. E.g. in the case of GlassFish/Payara
-            a soteria-1.0-m03-SNAPSHOT.jar in [gf_home]/glassfish/modules 
+            a soteria-1.0-m04-SNAPSHOT.jar in [gf_home]/glassfish/modules 
           -->
         <profile>
             <id>provided</id>
@@ -129,7 +129,7 @@
                 <dependency>
                    <groupId>javax.security</groupId>
                    <artifactId>javax.security-api</artifactId>
-                   <version>1.0-m03-SNAPSHOT</version>
+                   <version>1.0-m04-SNAPSHOT</version>
                    <scope>provided</scope>
                 </dependency>
             </dependencies>
@@ -139,7 +139,7 @@
             This profile assumes a target that does not have the Soteria libraries. 
             E.g. a Java EE 7 server or Servlet container such as Tomcat or Jetty.
             
-            With this profile e.g. soteria-1.0-m03-SNAPSHOT.jar will end up in WEB-INF/lib
+            With this profile e.g. soteria-1.0-m04-SNAPSHOT.jar will end up in WEB-INF/lib
         -->
         <profile>
             <id>bundled</id>
@@ -150,7 +150,7 @@
                 <dependency>
                     <groupId>org.glassfish.soteria</groupId>
                     <artifactId>soteria</artifactId>
-                    <version>1.0-m03-SNAPSHOT</version>
+                    <version>1.0-m04-SNAPSHOT</version>
                 </dependency>
             </dependencies>
         </profile> 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
        <groupId>org.glassfish.soteria</groupId>
        <artifactId>parent</artifactId>
-       <version>1.0-m04-SNAPSHOT</version>
+       <version>1.0-m05-SNAPSHOT</version>
     </parent>
     
     <groupId>org.glassfish.soteria.test</groupId>
@@ -123,7 +123,7 @@
         <!-- 
             This profile assumes a target that already has the Soteria libraries. 
             In Java EE 8 that would be the default. E.g. in the case of GlassFish/Payara
-            a soteria-1.0-m04-SNAPSHOT.jar in [gf_home]/glassfish/modules 
+            a soteria-1.0-m05-SNAPSHOT.jar in [gf_home]/glassfish/modules 
           -->
         <profile>
             <id>provided</id>
@@ -141,7 +141,7 @@
             This profile assumes a target that does not have the Soteria libraries. 
             E.g. a Java EE 7 server or Servlet container such as Tomcat or Jetty.
             
-            With this profile e.g. soteria-1.0-m04-SNAPSHOT.jar will end up in WEB-INF/lib
+            With this profile e.g. soteria-1.0-m05-SNAPSHOT.jar will end up in WEB-INF/lib
         -->
         <profile>
             <id>bundled</id>
@@ -152,7 +152,7 @@
                 <dependency>
                     <groupId>org.glassfish.soteria</groupId>
                     <artifactId>soteria</artifactId>
-                    <version>1.0-m04-SNAPSHOT</version>
+                    <version>1.0-m05-SNAPSHOT</version>
                 </dependency>
             </dependencies>
         </profile> 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -49,6 +49,8 @@
         <module>app-custom-rememberme</module>
 
         <module>app-custom-identity-store-handler</module>
+
+        <module>app-jaxrs</module>
     </modules>
     
     <dependencyManagement>


### PR DESCRIPTION
This updates track the current changes in the javax.security API Public Review Draft.

It also updates the version on Soteria to 1.0-m04-SNAPSHOT which (kind of) matches the version in the javax.security API.

Along with the version bump there is one other item that will require discussion.

SecurityContextImpl.java#86 no longer includes an override annotation for getAllDeclaredCallerRoles(). This has been discussed on the mailing list as no longer being included in the spec, but here I have only removed the annotation and updated the tests to still pass.

Last things to note is that I have an open Pull Request on the javax.security API to fix a bug in the ClientValidationRequest class (it was not using the passed in validation status and always using VALID). Once that PR is accepted the integration tests will pass on Wildfly and Payara.

The integration tests do not currently pass on Liberty and TomEE and I will try to look into that today.