### PR TITLE
Add Glassfish profile for running tests against glassfish.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Testing against any of these is done by activating the maven profile with the sa
 
 ``mvn clean install -Ptomee,bundled``
 
+Testing against glassfish (which provides soteria integration):
+``mvn clean verify -Pglassfish,provided``
 
 Compatibility
 -------------

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <!-- Test servers -->
         <payara.version>4.1.2.172</payara.version>
-        <glassfish.version>5.0-b08</glassfish.version>
+        <glassfish.version>5.0-b09</glassfish.version>
         <wildfly.version>10.1.0.Final</wildfly.version>
         <tomee.version>7.0.2</tomee.version>
         <liberty.version>16.0.0.3</liberty.version>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -158,10 +158,7 @@
         <profile>
             <id>glassfish</id>
             
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <repositories>
+           <repositories>
                 <repository>
                     <id>glassfish Promoted</id>
                     <url>https://maven.java.net/content/repositories/promoted/</url>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <!-- Test servers -->
         <payara.version>4.1.2.172</payara.version>
-        <glassfish.version>4.1.1</glassfish.version>
+        <glassfish.version>5.0-b08</glassfish.version>
         <wildfly.version>10.1.0.Final</wildfly.version>
         <tomee.version>7.0.2</tomee.version>
         <liberty.version>16.0.0.3</liberty.version>
@@ -154,8 +154,85 @@
                     <version>1.0-b08-SNAPSHOT</version>
                 </dependency>
             </dependencies>
+        </profile> 
+        <profile>
+            <id>glassfish</id>
+            
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>glassfish Promoted</id>
+                    <url>https://maven.java.net/content/repositories/promoted/</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+			
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-glassfish-managed-3.1</artifactId>
+                    <version>1.0.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+			
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.glassfish.main.distributions</groupId>
+                                            <artifactId>glassfish</artifactId>
+                                            <version>${glassfish.version}</version>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.19.1</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <environmentVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/glassfish5</GLASSFISH_HOME>
+                            </environmentVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
+        
         <profile>
             <id>payara</id>
 
@@ -534,4 +611,3 @@
     </profiles>
 
 </project>
-


### PR DESCRIPTION
With the latest promoted glassfish [build](http://download.oracle.com/glassfish/5.0/promoted/) which has JSR 375 RI (soteria) integrated, we can the run the soteria tests against glassfish 5.0-b09.

Verified locally pass by running 
``mvn clean verify -Pglassfish,provided``