### PR TITLE
Add Snapshot repository of maven.java.net.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,16 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    <repositories>
+       <repository>
+          <id>glassfish snapshots</id>
+          <url>https://maven.java.net/content/repositories/snapshots/</url>
+          <snapshots>
+              <enabled>true</enabled>
+          </snapshots>
+       </repository>
+     </repositories>
+
 
     <build>
         <pluginManagement>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <!-- Test servers -->
         <payara.version>4.1.2.172</payara.version>
-        <glassfish.version>5.0-b09</glassfish.version>
+        <glassfish.version>LATEST</glassfish.version>
         <wildfly.version>10.1.0.Final</wildfly.version>
         <tomee.version>7.0.2</tomee.version>
         <liberty.version>16.0.0.3</liberty.version>


### PR DESCRIPTION
Will had published the snapshot artifacts to maven.java.net snapshot repos. So this need to added to get the 1.0-b07-SNAPSHOT. Also we are currently setting up CI job for continuous deployment of soteria and api snapshot artifacts. Also additional change is make test/pom.xml use latest glassfish promoted builds.