### PR TITLE
Use repository url from parent pom and change repository id.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
     </dependencies>
     <repositories>
        <repository>
-          <id>glassfish snapshots</id>
-          <url>https://maven.java.net/content/repositories/snapshots/</url>
+          <id>jvnet-nexus-snapshots</id>
+          <url>${jvnetDistMgmtSnapshotsUrl}</url>
           <snapshots>
               <enabled>true</enabled>
           </snapshots>


### PR DESCRIPTION
The project already uses parent pom from http://central.maven.org/maven2/net/java/jvnet-parent/5/jvnet-parent-5.pom, which has the snapshot repo url configured. Also the id needs to be changed, as the current id does not exist as mirror in internal CI jobs, breaking the CI jobs.