### PR TITLE
Tweaks to PlaintextPasswordHashImpl prior to removal

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/identitystores/hash/PasswordHashCompare.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/hash/PasswordHashCompare.java
@@ -9,8 +9,7 @@ public class PasswordHashCompare {
      * to guess passwords.
      * <p>
      * The two hashes can be different lengths if the hash algorithm
-     * or parameters used to generate them weren't the same, or if comparing
-     * plaintext passwords.
+     * or parameters used to generate them weren't the same.
      * <p>
      * Use the length of the first parameter (hash of the password being verified)
      * to determine how many bytes are compared, so that the comparison time
@@ -35,6 +34,11 @@ public class PasswordHashCompare {
 
     /**
      * Compare two passwords, represented as character arrays.
+     * <p>
+     * Note that passwords should never be stored as plaintext,
+     * but this method may be useful for, e.g., verifying a
+     * password stored in encrypted form in a database, and
+     * decrypted for comparison.
      * <p>
      * Behavior and theory operation are the same as for
      * {@link #compareBytes(byte[], byte[]) compareBytes},

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/hash/PlaintextPasswordHashImpl.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/hash/PlaintextPasswordHashImpl.java
@@ -43,10 +43,10 @@ import java.util.Arrays;
 import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.identitystore.PlaintextPasswordHash;
+import javax.security.enterprise.identitystore.PasswordHash;
 
 @ApplicationScoped
-public class PlaintextPasswordHashImpl implements PlaintextPasswordHash {
+public class PlaintextPasswordHashImpl implements PasswordHash {
 
     @Override
     public void initialize(Map<String, String> parameters) {
@@ -60,6 +60,10 @@ public class PlaintextPasswordHashImpl implements PlaintextPasswordHash {
 
     @Override
     public boolean verify(char[] password, String hashedPassword) {
-        return PasswordHashCompare.compareChars(password, hashedPassword.toCharArray());
+        // don't bother with constant time comparison; more portable
+        // this way, and algorithm will be used only for testing.
+        return (password != null && password.length > 0 &&
+                hashedPassword != null && hashedPassword.length() > 0 &&
+                hashedPassword.equals(new String(password)));
     }
 }


### PR DESCRIPTION
Update PlaintextPasswordHashImpl so that it doesn't depend on internal RI class PasswordHashCompare. TCK team may want this for testing purposes after it's removed from the RI.