### PR TITLE
Changed artifacts to application scoped

### DIFF
--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -40,6 +40,7 @@
 package org.glassfish.soteria.test;
 
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.security.enterprise.AuthenticationException;
@@ -61,7 +62,7 @@ import static javax.security.enterprise.identitystore.CredentialValidationResult
     cookieSecureOnly = false, // normally not recommended, but easier for dev/test
     isRememberMeExpression ="#{self.isRememberMe(httpMessageContext)}"
 )
-@RequestScoped
+@ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
     
     @Inject

--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -45,13 +45,13 @@ import static javax.security.enterprise.identitystore.CredentialValidationResult
 
 import java.util.HashSet;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.security.enterprise.credential.Credential;
 import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
 
-@RequestScoped
+@ApplicationScoped
 public class TestIdentityStore implements IdentityStore {
 
     @Override

--- a/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -39,8 +39,7 @@
  */
 package org.glassfish.soteria.test;
 
-
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
@@ -56,7 +55,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 
-@RequestScoped
+@ApplicationScoped
 @AutoApplySession
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
     

--- a/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -45,13 +45,13 @@ import static javax.security.enterprise.identitystore.CredentialValidationResult
 
 import java.util.HashSet;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.security.enterprise.credential.Credential;
 import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
 
-@RequestScoped
+@ApplicationScoped
 public class TestIdentityStore implements IdentityStore {
 
     @Override

--- a/test/app-custom/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-custom/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -40,7 +40,7 @@
 package org.glassfish.soteria.test;
 
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
@@ -54,7 +54,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 
-@RequestScoped
+@ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
     
     @Inject

--- a/test/app-custom/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -44,12 +44,12 @@ import static javax.security.enterprise.identitystore.CredentialValidationResult
 
 import java.util.HashSet;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
 
-@RequestScoped
+@ApplicationScoped
 public class TestIdentityStore implements IdentityStore {
 
     public CredentialValidationResult validate(UsernamePasswordCredential usernamePasswordCredential) {

--- a/test/app-db/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-db/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -40,7 +40,7 @@
 package org.glassfish.soteria.test;
 
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
@@ -55,7 +55,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 
-@RequestScoped
+@ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
     
     @Inject

--- a/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -45,7 +45,7 @@ import static org.glassfish.soteria.test.Utils.notNull;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
 import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
@@ -55,7 +55,7 @@ import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@RequestScoped
+@ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
 
     @Override

--- a/test/app-ldap/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-ldap/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -42,7 +42,7 @@ package org.glassfish.soteria.test;
 import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.test.Utils.notNull;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
@@ -55,7 +55,7 @@ import javax.security.enterprise.identitystore.IdentityStoreHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@RequestScoped
+@ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
     
     @Inject

--- a/test/app-ldap2/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-ldap2/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -42,7 +42,7 @@ package org.glassfish.soteria.test;
 import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.test.Utils.notNull;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
@@ -55,7 +55,7 @@ import javax.security.enterprise.identitystore.IdentityStoreHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@RequestScoped
+@ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
 
     @Inject

--- a/test/app-mem-basic/src/main/java/test/TestIdentityStore.java
+++ b/test/app-mem-basic/src/main/java/test/TestIdentityStore.java
@@ -44,12 +44,12 @@ import static javax.security.enterprise.identitystore.CredentialValidationResult
 
 import java.util.HashSet;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
 
-@RequestScoped
+@ApplicationScoped
 public class TestIdentityStore implements IdentityStore {
 
     public CredentialValidationResult validate(UsernamePasswordCredential usernamePasswordCredential) {

--- a/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -44,12 +44,12 @@ import static javax.security.enterprise.identitystore.CredentialValidationResult
 
 import java.util.HashSet;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
 
-@RequestScoped
+@ApplicationScoped
 public class TestIdentityStore implements IdentityStore {
 
     public CredentialValidationResult validate(UsernamePasswordCredential usernamePasswordCredential) {

--- a/test/app-mem-form/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-mem-form/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -44,12 +44,12 @@ import static javax.security.enterprise.identitystore.CredentialValidationResult
 
 import java.util.HashSet;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
 
-@RequestScoped
+@ApplicationScoped
 public class TestIdentityStore implements IdentityStore {
 
     public CredentialValidationResult validate(UsernamePasswordCredential usernamePasswordCredential) {

--- a/test/app-mem/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-mem/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -42,7 +42,7 @@ package org.glassfish.soteria.test;
 import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.test.Utils.notNull;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
@@ -55,7 +55,7 @@ import javax.security.enterprise.identitystore.IdentityStoreHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@RequestScoped
+@ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
     
     @Inject

--- a/test/app-mem/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-mem/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -44,12 +44,12 @@ import static javax.security.enterprise.identitystore.CredentialValidationResult
 
 import java.util.HashSet;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
 
-@RequestScoped
+@ApplicationScoped
 public class TestIdentityStore implements IdentityStore {
 
     public CredentialValidationResult validate(UsernamePasswordCredential usernamePasswordCredential) {

--- a/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -42,7 +42,7 @@ package org.glassfish.soteria.test;
 import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.test.Utils.notNull;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
@@ -55,7 +55,7 @@ import javax.security.enterprise.identitystore.IdentityStoreHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@RequestScoped
+@ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
     
     @Inject

--- a/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestBackupIdentityStore.java
+++ b/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestBackupIdentityStore.java
@@ -45,13 +45,13 @@ import static javax.security.enterprise.identitystore.CredentialValidationResult
 
 import java.util.HashSet;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.security.enterprise.credential.Credential;
 import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
 
-@RequestScoped
+@ApplicationScoped
 public class TestBackupIdentityStore implements IdentityStore {
 
     @Override

--- a/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthenticationIdentityStore.java
+++ b/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthenticationIdentityStore.java
@@ -50,7 +50,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.security.enterprise.credential.Credential;
 import javax.security.enterprise.credential.UsernamePasswordCredential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
@@ -59,7 +59,7 @@ import javax.security.enterprise.identitystore.IdentityStore;
 /**
  *
  */
-@RequestScoped
+@ApplicationScoped
 public class AuthenticationIdentityStore implements IdentityStore {
 
     private Map<String, String> callerToPassword;

--- a/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthorizationIdentityStore.java
+++ b/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthorizationIdentityStore.java
@@ -48,14 +48,14 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStore;
 
 /**
  *
  */
-@RequestScoped
+@ApplicationScoped
 public class AuthorizationIdentityStore implements IdentityStore {
 
     private Map<String, Set<String>> authorization;

--- a/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -39,6 +39,7 @@
  */
 package org.glassfish.soteria.test;
 
+import javax.enterprise.context.ApplicationScoped;
 import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.test.Utils.notNull;
 
@@ -55,7 +56,7 @@ import javax.security.enterprise.identitystore.IdentityStoreHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@RequestScoped
+@ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
     
     @Inject

--- a/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -44,7 +44,7 @@ import static javax.security.enterprise.AuthenticationStatus.SEND_FAILURE;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
 import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
@@ -54,7 +54,7 @@ import javax.security.enterprise.credential.Credential;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@RequestScoped
+@ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
 
     @Override

--- a/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -45,7 +45,7 @@ import static org.glassfish.soteria.test.Utils.notNull;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.ApplicationScoped;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
 import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
@@ -55,7 +55,7 @@ import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@RequestScoped
+@ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
 
     @Override


### PR DESCRIPTION
`IdentityStore`s and `HttpAuthenticationMechanism`s are inherently stateless and the spec forces the built-in ones to be @ApplicationScoped.

Tests should show this since users will go there to search for examples.