### PR TITLE
[WIP] Added basic validation for EL expressions

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/cdi/AnnotationELPProcessor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/AnnotationELPProcessor.java
@@ -195,7 +195,7 @@ public class AnnotationELPProcessor {
     public static void validateExpressions(String... expressions) {
         // This method should create real Expressions to verify correctness. Do a basic syntax check for now.
         for (String expression : expressions) {
-            if (!isELExpression(expression)) {
+            if (!"".equals(expression) && !isELExpression(expression)) {
                 throw new IllegalArgumentException(expression + " is not a valid EL expression");
             }
         }

--- a/impl/src/main/java/org/glassfish/soteria/cdi/AnnotationELPProcessor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/AnnotationELPProcessor.java
@@ -184,6 +184,23 @@ public class AnnotationELPProcessor {
         return stream(expressions).anyMatch(expr -> isELExpression(expr));
     }
     
+    /**
+     * Verifies EL expression correctness. Only values that are known to be EL
+     * expressions should be passed as parameters to this method.
+     *
+     * @param expressions
+     * @throws IllegalArgumentException if any of the expressions is invalid
+     */
+    @SafeVarargs
+    public static void validateExpressions(String... expressions) {
+        // This method should create real Expressions to verify correctness. Do a basic syntax check for now.
+        for (String expression : expressions) {
+            if (!isELExpression(expression)) {
+                throw new IllegalArgumentException(expression + " is not a valid EL expression");
+            }
+        }
+    }
+    
     private static boolean isELExpression(String expression) {
         return !isEmpty(expression) && (isDeferredExpression(expression) || isImmediateExpression(expression));
     }

--- a/impl/src/main/java/org/glassfish/soteria/cdi/DatabaseIdentityStoreDefinitionAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/DatabaseIdentityStoreDefinitionAnnotationLiteral.java
@@ -96,6 +96,8 @@ public class DatabaseIdentityStoreDefinitionAnnotationLiteral extends Annotation
     }
     
     public static DatabaseIdentityStoreDefinition eval(DatabaseIdentityStoreDefinition in) {
+        validateExpressionProperties(in);
+        
         if (!hasAnyELExpression(in)) {
             return in;
         }
@@ -115,6 +117,13 @@ public class DatabaseIdentityStoreDefinitionAnnotationLiteral extends Annotation
         out.setHasDeferredExpressions(hasAnyELExpression(out));
         
         return out;
+    }
+    
+    public static void validateExpressionProperties(DatabaseIdentityStoreDefinition in) {
+        AnnotationELPProcessor.validateExpressions(
+                in.priorityExpression(),
+                in.useForExpression()
+        );
     }
     
     public static boolean hasAnyELExpression(DatabaseIdentityStoreDefinition in) {

--- a/impl/src/main/java/org/glassfish/soteria/cdi/LdapIdentityStoreDefinitionAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/LdapIdentityStoreDefinitionAnnotationLiteral.java
@@ -42,6 +42,7 @@ package org.glassfish.soteria.cdi;
 import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalELExpression;
 
 import javax.enterprise.util.AnnotationLiteral;
+import javax.security.enterprise.identitystore.DatabaseIdentityStoreDefinition;
 import javax.security.enterprise.identitystore.IdentityStore.ValidationType;
 import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition;
 
@@ -138,6 +139,8 @@ public class LdapIdentityStoreDefinitionAnnotationLiteral extends AnnotationLite
     }
     
     public static LdapIdentityStoreDefinition eval(LdapIdentityStoreDefinition in) {
+        validateExpressionProperties(in);
+        
         if (!hasAnyELExpression(in)) {
             return in;
         }
@@ -179,6 +182,17 @@ public class LdapIdentityStoreDefinitionAnnotationLiteral extends AnnotationLite
             
             throw t;
         }
+    }
+    
+    public static void validateExpressionProperties(LdapIdentityStoreDefinition in) {
+        AnnotationELPProcessor.validateExpressions(
+                in.callerSearchScopeExpression(),
+                in.groupSearchScopeExpression(),
+                in.maxResultsExpression(),
+                in.priorityExpression(),
+                in.readTimeoutExpression(),
+                in.useForExpression()
+        );
     }
     
     public static boolean hasAnyELExpression(LdapIdentityStoreDefinition in) {

--- a/impl/src/main/java/org/glassfish/soteria/cdi/LoginToContinueAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/LoginToContinueAnnotationLiteral.java
@@ -45,6 +45,7 @@ import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalImmediate;
 
 import javax.enterprise.util.AnnotationLiteral;
 import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
+import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition;
 
 /**
  * An annotation literal for <code>@LoginToContinue</code>.
@@ -70,6 +71,8 @@ public class LoginToContinueAnnotationLiteral extends AnnotationLiteral<LoginToC
     }
     
     public static LoginToContinue eval(LoginToContinue in) {
+        validateExpressionProperties(in);
+        
         if (!hasAnyELExpression(in)) {
             return in;
         }
@@ -91,6 +94,12 @@ public class LoginToContinueAnnotationLiteral extends AnnotationLiteral<LoginToC
             
             throw t;
         }
+    }
+    
+    public static void validateExpressionProperties(LoginToContinue in) {
+        AnnotationELPProcessor.validateExpressions(
+                in.useForwardToLoginExpression()
+        );
     }
     
     public static boolean hasAnyELExpression(LoginToContinue in) {

--- a/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeAnnotationLiteral.java
@@ -46,6 +46,7 @@ import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalImmediate;
 import javax.el.ELProcessor;
 import javax.enterprise.util.AnnotationLiteral;
 import javax.security.enterprise.authentication.mechanism.http.RememberMe;
+import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition;
 
 /**
  * An annotation literal for <code>@RememberMe</code>.
@@ -99,6 +100,8 @@ public class RememberMeAnnotationLiteral extends AnnotationLiteral<RememberMe> i
     }
     
     public static RememberMe eval(RememberMe in, ELProcessor elProcessor) {
+        validateExpressionProperties(in);
+        
         if (!hasAnyELExpression(in)) {
             return in;
         }
@@ -126,6 +129,15 @@ public class RememberMeAnnotationLiteral extends AnnotationLiteral<RememberMe> i
             
             throw t;
         }
+    }
+    
+    public static void validateExpressionProperties(RememberMe in) {
+        AnnotationELPProcessor.validateExpressions(
+                in.cookieMaxAgeSecondsExpression(),
+                in.cookieSecureOnlyExpression(),
+                in.cookieHttpOnlyExpression(),
+                in.isRememberMeExpression()
+        );
     }
     
     public static boolean hasAnyELExpression(RememberMe in) {

--- a/impl/src/test/java/org/glassfish/soteria/identitystores/hash/ExpressionValidationImplTest.java
+++ b/impl/src/test/java/org/glassfish/soteria/identitystores/hash/ExpressionValidationImplTest.java
@@ -1,0 +1,149 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.soteria.identitystores.hash;
+
+import java.lang.annotation.Annotation;
+import javax.security.enterprise.identitystore.DatabaseIdentityStoreDefinition;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.security.enterprise.identitystore.IdentityStore;
+import javax.security.enterprise.identitystore.IdentityStore.ValidationType;
+import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition;
+import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition.LdapSearchScope;
+import javax.security.enterprise.identitystore.PasswordHash;
+
+import org.glassfish.soteria.cdi.DatabaseIdentityStoreDefinitionAnnotationLiteral;
+import org.glassfish.soteria.cdi.LdapIdentityStoreDefinitionAnnotationLiteral;
+
+public class ExpressionValidationImplTest {
+
+    private DatabaseIdentityStoreDefinitionAnnotationLiteral validDatabase;
+    private DatabaseIdentityStoreDefinitionAnnotationLiteral invalidDatabasePriority;
+    private DatabaseIdentityStoreDefinitionAnnotationLiteral invalidDatabaseUseFor;
+
+    private LdapIdentityStoreDefinitionAnnotationLiteral validLdap;
+    private LdapIdentityStoreDefinitionAnnotationLiteral invalidLdapCallerSearchScope;
+    private LdapIdentityStoreDefinitionAnnotationLiteral invalidLdapGroupSearchScope;
+    private LdapIdentityStoreDefinitionAnnotationLiteral invalidLdapMaxResultsExpression;
+    private LdapIdentityStoreDefinitionAnnotationLiteral invalidLdapPriorityExpression;
+    private LdapIdentityStoreDefinitionAnnotationLiteral invalidLdapReadTimeout;
+    private LdapIdentityStoreDefinitionAnnotationLiteral invalidLdapUseForExpression;
+
+    @Before
+    public void init() {
+        validDatabase = createDatabaseIdentityStoreDefinition("#{foo.bar}", "#{foo.bar}");
+        invalidDatabasePriority = createDatabaseIdentityStoreDefinition("xx", "#{foo.bar}");
+        invalidDatabaseUseFor = createDatabaseIdentityStoreDefinition("#{foo.bar}", "xx");
+
+        validLdap = createLdapIdentityStoreDefinition("#{foo.bar}", "#{foo.bar}", "#{foo.bar}", "#{foo.bar}", "#{foo.bar}", "#{foo.bar}");
+        invalidLdapCallerSearchScope = createLdapIdentityStoreDefinition("xx", "#{foo.bar}", "#{foo.bar}", "#{foo.bar}", "#{foo.bar}", "#{foo.bar}");
+        invalidLdapGroupSearchScope = createLdapIdentityStoreDefinition("#{foo.bar}", "xx", "#{foo.bar}", "#{foo.bar}", "#{foo.bar}", "#{foo.bar}");
+        invalidLdapMaxResultsExpression = createLdapIdentityStoreDefinition("#{foo.bar}", "#{foo.bar}", "xx", "#{foo.bar}", "#{foo.bar}", "#{foo.bar}");
+        invalidLdapPriorityExpression = createLdapIdentityStoreDefinition("#{foo.bar}", "#{foo.bar}", "#{foo.bar}", "xx", "#{foo.bar}", "#{foo.bar}");
+        invalidLdapReadTimeout = createLdapIdentityStoreDefinition("#{foo.bar}", "#{foo.bar}", "#{foo.bar}", "#{foo.bar}", "xx", "#{foo.bar}");
+        invalidLdapUseForExpression = createLdapIdentityStoreDefinition("#{foo.bar}", "#{foo.bar}", "#{foo.bar}", "#{foo.bar}", "#{foo.bar}", "xx");
+    }
+
+    @Test
+    public void testValidDatabase() {
+        DatabaseIdentityStoreDefinitionAnnotationLiteral.eval(validDatabase);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFailsDatabasePriority() {
+        DatabaseIdentityStoreDefinitionAnnotationLiteral.eval(invalidDatabasePriority);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFailsDatabaseUseFor() {
+        DatabaseIdentityStoreDefinitionAnnotationLiteral.eval(invalidDatabaseUseFor);
+    }
+
+    @Test
+    public void testValidLdap() {
+        LdapIdentityStoreDefinitionAnnotationLiteral.eval(validLdap);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFailsLdapCallerSearchScope() {
+        LdapIdentityStoreDefinitionAnnotationLiteral.eval(invalidLdapCallerSearchScope);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFailsLdapGroupSearchScope() {
+        LdapIdentityStoreDefinitionAnnotationLiteral.eval(invalidLdapGroupSearchScope);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFailsLdapMaxResults() {
+        LdapIdentityStoreDefinitionAnnotationLiteral.eval(invalidLdapMaxResultsExpression);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFailsLdapPriority() {
+        LdapIdentityStoreDefinitionAnnotationLiteral.eval(invalidLdapPriorityExpression);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFailsLdapReadTimeout() {
+        LdapIdentityStoreDefinitionAnnotationLiteral.eval(invalidLdapReadTimeout);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFailsLdapUseFor() {
+        LdapIdentityStoreDefinitionAnnotationLiteral.eval(invalidLdapUseForExpression);
+    }
+
+    private DatabaseIdentityStoreDefinitionAnnotationLiteral createDatabaseIdentityStoreDefinition(String priorityExpression, String useForExpression) {
+        return new DatabaseIdentityStoreDefinitionAnnotationLiteral(
+                "java:comp/DefaultDataSource", "", "", Pbkdf2PasswordHashImpl.class, new String[]{},
+                0, priorityExpression, IdentityStore.ValidationType.values(), useForExpression);
+    }
+
+    private LdapIdentityStoreDefinitionAnnotationLiteral createLdapIdentityStoreDefinition(
+            String callerSearchScopeExpression, String groupSearchScopeExpression, String maxResultsExpression, String priorityExpression, String readTimeoutExpression,
+            String useForExpression) {
+        return new LdapIdentityStoreDefinitionAnnotationLiteral(
+                "", "", "", "uid", "", "", LdapIdentityStoreDefinition.LdapSearchScope.SUBTREE, callerSearchScopeExpression, "member", "memberOf",
+                "cn", "", "", LdapIdentityStoreDefinition.LdapSearchScope.SUBTREE, groupSearchScopeExpression, 1000, maxResultsExpression, 80, priorityExpression, 0,
+                readTimeoutExpression, "", IdentityStore.ValidationType.values(), useForExpression);
+    }
+}


### PR DESCRIPTION
Fixes #123 and partially #104 (the part we can make without more discussion). This makes a *very* simple check intented only for xxExpression attributes where we know for sure we expect an expression.

This is still a work in progress. Remaining stuff is:

- [x] Wait for existing tests to pass
- [ ] Add a new test to assert behavior
- [ ] Make the deployment fail if the expressions are invalid
- [ ] Create actual expressions to verify correctness instead of just checking the beginning and end of the string.