### PR TITLE
Small tweaks to exception handling

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/authorization/JACC.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/JACC.java
@@ -163,7 +163,7 @@ public class JACC {
             });
             return ctx;
         } catch (PrivilegedActionException e) {
-            throw new IllegalStateException(e.getException());
+            throw new IllegalStateException(e.getCause());
         }
     }
     

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/DatabaseIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/DatabaseIdentityStore.java
@@ -194,6 +194,8 @@ public class DatabaseIdentityStore implements IdentityStore {
             if (dataSource == null) {
                 throw new IdentityStoreConfigurationException("Jndi lookup failed for DataSource " + dataBaseIdentityStoreDefinition.dataSourceLookup());
             }
+        } catch (IdentityStoreConfigurationException e) {
+            throw e;
         } catch (Exception e) {
             throw new IdentityStoreRuntimeException(e);
         }


### PR DESCRIPTION
Fixed two small issues:
- `DatabaseIdentityStore.getDataSource()` was throwing `IdentityStoreConfigurationException`, then catching it and wrapping it in an `IdentityStoreRuntimeException`. Changed the code to explicitly catch and rethrow config exceptions, so that config problems don't appear as runtime problems.
- Tweaked `JACC.getFromContext()` to call `getCause()` instead of `getException()` to obtain the exception thrown by the `PrivilegedExceptionAction`.