### PR TITLE
Fix RememberMeInterceptor.cleanSubject()

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
@@ -189,7 +189,8 @@ public class RememberMeInterceptor implements Serializable {
             // And remove the token (and with it the authenticated identity) from the store
             rememberMeIdentityStore.removeLoginToken(rememberMeCookie.getValue());
         }
-        
+
+        invocationContext.proceed();
     }
     
     private RememberMe getRememberMeFromIntercepted(ELProcessor elProcessor) {

--- a/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
@@ -174,7 +174,7 @@ public class RememberMeInterceptor implements Serializable {
         return authstatus;
     }
     
-    private void cleanSubject(InvocationContext invocationContext, HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) {
+    private void cleanSubject(InvocationContext invocationContext, HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) throws Exception {
     
         RememberMeIdentityStore rememberMeIdentityStore = CDI.current().select(RememberMeIdentityStore.class).get(); // TODO ADD CHECKS
         RememberMe rememberMeAnnotation = getRememberMeFromIntercepted(getElProcessor(invocationContext, httpMessageContext));


### PR DESCRIPTION
`RememberMeInterceptor.cleanSubject()` was not delegating to the interceptor chain/target HAM, so the `Subject` could never actually be cleaned if `RememberMeInterceptor` was deployed. Existing implementation only removed the caller's cookie and called `rememberMeIdentityStore.removeLoginToken()`.

- Added call to `invocationContext.proceed()`.
- Added `throws` clause to handle `Exception` declared by `proceed()`.

Fixes #174