### PR TITLE
Add glassfish remote profile, SecurityContext test changes

### DIFF
--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/Ejb.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/Ejb.java
@@ -44,6 +44,7 @@ import java.security.Principal;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.security.enterprise.SecurityContext;
+import java.util.Set;
 
 @Stateless
 public class Ejb {
@@ -53,5 +54,8 @@ public class Ejb {
 
     public Principal getPrincipal() {
         return sc.getCallerPrincipal();
+    }
+    public <T extends Principal> Set<T> getPrincipalsByType(Class<T> pType){
+        return sc.getPrincipalsByType(pType);
     }
 }

--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/EjbServlet.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/EjbServlet.java
@@ -51,6 +51,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.security.Principal;
 
 /**
  * Test Servlet that authenticates that authenticates the request and returns
@@ -71,7 +72,15 @@ public class EjbServlet extends HttpServlet {
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         securityContext.authenticate(request, response, withParams());
 
-        response.getWriter().write(ejb.getPrincipal().getClass().getName());
+        response.getWriter().write(ejb.getPrincipal().getClass().getName()+",");
+
+        Principal applicationPrincipal;
+        if (request.getParameter("useCallerPrincipal") != null) {
+            applicationPrincipal=ejb.getPrincipalsByType(CustomCallerPrincipal.class).toArray(new CustomCallerPrincipal[0])[0];
+        } else {
+            applicationPrincipal=ejb.getPrincipalsByType(CustomPrincipal.class).toArray(new CustomPrincipal[0])[0];
+        }
+        response.getWriter().write(applicationPrincipal.getClass().getName());
     }
 
 }

--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -51,6 +51,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.security.Principal;
 
 /**
  * Test Servlet that authenticates that authenticates the request and returns
@@ -67,7 +68,14 @@ public class Servlet extends HttpServlet {
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         securityContext.authenticate(request, response, withParams());
 
-        response.getWriter().write(securityContext.getCallerPrincipal().getClass().getName());
+        response.getWriter().write(securityContext.getCallerPrincipal().getClass().getName()+",");
+        Principal applicationPrincipal;
+        if (request.getParameter("useCallerPrincipal") != null) {
+            applicationPrincipal=securityContext.getPrincipalsByType(CustomCallerPrincipal.class).toArray(new CustomCallerPrincipal[0])[0];
+        } else {
+            applicationPrincipal=securityContext.getPrincipalsByType(CustomPrincipal.class).toArray(new CustomPrincipal[0])[0];
+        }
+        response.getWriter().write(applicationPrincipal.getClass().getName());
     }
 
 }

--- a/test/app-securitycontext-customprincipal/src/test/java/org/glassfish/soteria/test/AppSecurityContextCallerPrincipalIT.java
+++ b/test/app-securitycontext-customprincipal/src/test/java/org/glassfish/soteria/test/AppSecurityContextCallerPrincipalIT.java
@@ -59,20 +59,29 @@ public class AppSecurityContextCallerPrincipalIT extends ArquillianBase {
 
     @Test
     public void testServletCustomPrincipal() {
-        assertTrue(readFromServer("/servlet")
-                .contains("org.glassfish.soteria.test.CustomPrincipal"));
+        String resp = readFromServer("/servlet");
+        assertTrue(isContainerPrincipalTypeInResponse(resp));
     }
 
     @Test
     public void testServletCustomCallerPrincipal() {
-        assertTrue(readFromServer("/servlet?useCallerPrincipal")
-                .contains("org.glassfish.soteria.test.CustomCallerPrincipal"));
+        String resp = readFromServer("/servlet?useCallerPrincipal");
+        assertTrue(isContainerPrincipalTypeInResponse(resp));
     }
 
     @Test
     public void testEjbCustomPrincipal() {
-        assertTrue(readFromServer("/ejb-servlet")
-                .contains("org.glassfish.soteria.test.CustomPrincipal"));
+        String resp = readFromServer("/ejb-servlet");
+        assertTrue(isContainerPrincipalTypeInResponse(resp));
     }
 
+    public boolean isContainerPrincipalTypeInResponse(String response) {
+        return response.contains("com.sun.enterprise.security.web.integration.WebPrincipal") ||
+                response.contains("weblogic.security.principal.WLSUserImpl") ||
+                response.contains("com.ibm.ws.security.authentication.principals.WSPrincipal") ||
+                response.contains("org.jboss.security.SimplePrincipal") ||
+                response.contains("org.jboss.security.SimpleGroup") ||
+                response.contains("org.apache.tomee.catalina.TomcatSecurityService$TomcatUser") ||
+                response.contains("org.glassfish.soteria.test.CustomPrincipal");
+    }
 }

--- a/test/app-securitycontext-customprincipal/src/test/java/org/glassfish/soteria/test/AppSecurityContextCallerPrincipalIT.java
+++ b/test/app-securitycontext-customprincipal/src/test/java/org/glassfish/soteria/test/AppSecurityContextCallerPrincipalIT.java
@@ -60,28 +60,40 @@ public class AppSecurityContextCallerPrincipalIT extends ArquillianBase {
     @Test
     public void testServletCustomPrincipal() {
         String resp = readFromServer("/servlet");
-        assertTrue(isContainerPrincipalTypeInResponse(resp));
+        assertTrue(isContainerPrincipalTypeInResponse(resp,false));
     }
 
     @Test
     public void testServletCustomCallerPrincipal() {
         String resp = readFromServer("/servlet?useCallerPrincipal");
-        assertTrue(isContainerPrincipalTypeInResponse(resp));
+        assertTrue(isContainerPrincipalTypeInResponse(resp,true));
     }
 
     @Test
     public void testEjbCustomPrincipal() {
         String resp = readFromServer("/ejb-servlet");
-        assertTrue(isContainerPrincipalTypeInResponse(resp));
+        assertTrue(isContainerPrincipalTypeInResponse(resp,false));
     }
 
-    public boolean isContainerPrincipalTypeInResponse(String response) {
-        return response.contains("com.sun.enterprise.security.web.integration.WebPrincipal") ||
-                response.contains("weblogic.security.principal.WLSUserImpl") ||
-                response.contains("com.ibm.ws.security.authentication.principals.WSPrincipal") ||
-                response.contains("org.jboss.security.SimplePrincipal") ||
-                response.contains("org.jboss.security.SimpleGroup") ||
-                response.contains("org.apache.tomee.catalina.TomcatSecurityService$TomcatUser") ||
-                response.contains("org.glassfish.soteria.test.CustomPrincipal");
+    @Test
+    public void testEjbCustomCallerPrincipal() {
+        String resp = readFromServer("/ejb-servlet?useCallerPrincipal");
+        assertTrue(isContainerPrincipalTypeInResponse(resp,true));
+    }
+
+    public boolean isContainerPrincipalTypeInResponse(String response, boolean isCallerPrincipalUsed) {
+        String[] principalArray = response.split(",");
+        String containerPrincipal = principalArray[0];
+        String applicationPrincipal = principalArray[1];
+        boolean isContainerPricipalCorrect = containerPrincipal.contains("com.sun.enterprise.security.web.integration.WebPrincipal") ||
+                containerPrincipal.contains("weblogic.security.principal.WLSUserImpl") ||
+                containerPrincipal.contains("com.ibm.ws.security.authentication.principals.WSPrincipal") ||
+                containerPrincipal.contains("org.jboss.security.SimplePrincipal") ||
+                containerPrincipal.contains("org.jboss.security.SimpleGroup") ||
+                containerPrincipal.contains("org.apache.tomee.catalina.TomcatSecurityService$TomcatUser") ||
+                containerPrincipal.contains("javax.security.enterprise.CallerPrincipal");
+
+        boolean isApplicationPrincipalCorrect = isCallerPrincipalUsed ? applicationPrincipal.contains("org.glassfish.soteria.test.CustomCallerPrincipal") : applicationPrincipal.contains("org.glassfish.soteria.test.CustomPrincipal");
+        return isContainerPricipalCorrect && isApplicationPrincipalCorrect;
     }
 }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -330,7 +330,44 @@
             </dependencies>
         </profile>
         
-        
+         <profile>
+            <id>glassfish-remote</id>
+            
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-glassfish-remote-3.1</artifactId> 
+                    <version>1.0.0.Final</version> 
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                   <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-failsafe-plugin</artifactId>
+                      <version>2.20</version>
+                      <executions>
+                        <execution>
+                          <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                          </goals>
+                        </execution>
+                      </executions>
+                      <configuration>
+                        <systemPropertyVariables>
+                          <finalName>${project.build.finalName}</finalName>
+                        </systemPropertyVariables>
+                        <environmentVariables>
+                          <GLASSFISH_HOME>${env.S1AS_HOME}/..</GLASSFISH_HOME>
+                        </environmentVariables>
+                      </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+       
         <profile>
             <id>wildfly</id>
 


### PR DESCRIPTION
1. Add glassfish remote profile, so soteria tests can be run against already running glassfish server.
2. As per spec 

> **SecurityContext.getCallerPrincipal()** method retrieves the Principal representing the caller. This is the container-specific representation of the caller principal, and the type may differ from the type of the caller principal originally established by an HttpAuthenticationMechanism.
> The **SecurityContext.getPrincipalsByType()** method retrieves all principals of the given type. This method can be used to retrieve an application-specific caller principal established during authentication. This method is primarily useful in the case that the container’s caller principal is a different type than the application caller principal, and the application needs specific information behavior available only from the application principal. 

The securityContext test needed to be changed to check for principal types for container and application separately.