### PR TITLE
Fix securitycontext test and enable them

### DIFF
--- a/test/app-securitycontext-customprincipal/pom.xml
+++ b/test/app-securitycontext-customprincipal/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0-b14-SNAPSHOT</version>
+        <version>1.0-b15-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-securitycontext-customprincipal</artifactId>

--- a/test/app-securitycontext-customprincipal/pom.xml
+++ b/test/app-securitycontext-customprincipal/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-b14-SNAPSHOT</version>
+            <version>1.0-b15-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-securitycontext-customprincipal/src/test/java/org/glassfish/soteria/test/AppSecurityContextCallerPrincipalIT.java
+++ b/test/app-securitycontext-customprincipal/src/test/java/org/glassfish/soteria/test/AppSecurityContextCallerPrincipalIT.java
@@ -85,15 +85,16 @@ public class AppSecurityContextCallerPrincipalIT extends ArquillianBase {
         String[] principalArray = response.split(",");
         String containerPrincipal = principalArray[0];
         String applicationPrincipal = principalArray[1];
+        String inputApplicationPrincipal = isCallerPrincipalUsed ? "org.glassfish.soteria.test.CustomCallerPrincipal" : "org.glassfish.soteria.test.CustomPrincipal";
         boolean isContainerPricipalCorrect = containerPrincipal.contains("com.sun.enterprise.security.web.integration.WebPrincipal") ||
                 containerPrincipal.contains("weblogic.security.principal.WLSUserImpl") ||
                 containerPrincipal.contains("com.ibm.ws.security.authentication.principals.WSPrincipal") ||
                 containerPrincipal.contains("org.jboss.security.SimplePrincipal") ||
                 containerPrincipal.contains("org.jboss.security.SimpleGroup") ||
                 containerPrincipal.contains("org.apache.tomee.catalina.TomcatSecurityService$TomcatUser") ||
-                containerPrincipal.contains("javax.security.enterprise.CallerPrincipal");
-
-        boolean isApplicationPrincipalCorrect = isCallerPrincipalUsed ? applicationPrincipal.contains("org.glassfish.soteria.test.CustomCallerPrincipal") : applicationPrincipal.contains("org.glassfish.soteria.test.CustomPrincipal");
+                containerPrincipal.contains("javax.security.enterprise.CallerPrincipal") ||
+                containerPrincipal.contains(inputApplicationPrincipal);
+        boolean isApplicationPrincipalCorrect = applicationPrincipal.contains(inputApplicationPrincipal);
         return isContainerPricipalCorrect && isApplicationPrincipalCorrect;
     }
 }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -29,9 +29,7 @@
 
         <module>app-securitycontext</module>
         <module>app-securitycontext-auth</module>
-	<!--
         <module>app-securitycontext-customprincipal</module>
-	-->
 
         <!-- app-[identity-store] -->
         <module>app-mem</module>


### PR DESCRIPTION
Fixes securitycontext customprincipal tests. Fix is to handle payara's ([payara#294](https://github.com/payara/Payara/pull/294)) version of HttpServletRequest.getUserPrincipal() which does not return WebPrincipal instance but returns whatever SAM has put in callbackhandler. 