### PR TITLE
Update README.md (remove API references from EDR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,7 @@
 
 [![Build Status](https://travis-ci.org/javaee/security-soteria.svg?branch=master)](https://travis-ci.org/javaee/security-soteria)
 
-Java EE Security (JSR 375) upstream API and RI
-
-Notes
------
-
-The API in the /api module is the *upstream API*, which means development takes place there. At set times a version of this will be synced to java.net representing "the truth". 
-From java.net the API will be mirrored back to https://github.com/javaee-security-spec/spec-api
-
-Currently Soteria is working towards an EDR1 release.
+Java EE Security (JSR 375) RI
 
 Building
 --------


### PR DESCRIPTION
Fixed EDR status notes no longer relevant
There were some things in the readme from an old RI-API combination that have no relevance since at least Public Review.